### PR TITLE
Feat/add watch types

### DIFF
--- a/src/api/SampleProjectService/index.ts
+++ b/src/api/SampleProjectService/index.ts
@@ -8,13 +8,11 @@ import { GetSampleProjectResponseDto } from "@/types/dto/SampleProjectService";
 /**
  *
  */
-export const getSampleProject = (
-  id: number,
-): Promise<GetSampleProjectResponseDto> =>
-  // 올바른 fetch 방식인지 테스트 필요합니다. 원래 상대경로로 적었으나 next.js 18 버전 이상은 절대경로만 인식한다는 얘기가 있어서 일단 이렇게 적었습니다.
-  fetch(`/api/mock/project/${id}`).then((res) =>
-    res.ok ? res.json() : Promise.reject(res),
-  );
+export const getSampleProjectById =
+  (id: string) => (): Promise<GetSampleProjectResponseDto> =>
+    fetch(`/api/mock/project/${id}`).then((res) =>
+      res.ok ? res.json() : Promise.reject(res),
+    );
 
 export const postSampleProject = (
   body: any, // post body에 들어갈 타입은 user와 달리 정의되어 있지 않은데, 어떻게 구현하면 좋을까요?

--- a/src/api/SampleProjectService/index.ts
+++ b/src/api/SampleProjectService/index.ts
@@ -14,9 +14,8 @@ export const getSampleProjectById =
       res.ok ? res.json() : Promise.reject(res),
     );
 
-export const postSampleProject = (
-  id: string,
-): Promise<GetSampleProjectResponseDto> =>
-  fetch(`/api/mock/project/${id}/finish`, {
-    method: "POST",
-  }).then(async (res) => (res.ok ? res.json() : Promise.reject(res)));
+export const postSampleProjectById =
+  (id: string) => (): Promise<GetSampleProjectResponseDto> =>
+    fetch(`/api/mock/project/${id}/finish`, {
+      method: "POST",
+    }).then(async (res) => (res.ok ? res.json() : Promise.reject(res)));

--- a/src/api/SampleProjectService/index.ts
+++ b/src/api/SampleProjectService/index.ts
@@ -15,9 +15,8 @@ export const getSampleProjectById =
     );
 
 export const postSampleProject = (
-  body: any, // post body에 들어갈 타입은 user와 달리 정의되어 있지 않은데, 어떻게 구현하면 좋을까요?
+  id: string,
 ): Promise<GetSampleProjectResponseDto> =>
   fetch(`/api/mock/project/${id}/finish`, {
     method: "POST",
-    body: JSON.stringify(body),
   }).then(async (res) => (res.ok ? res.json() : Promise.reject(res)));

--- a/src/api/SampleProjectService/index.ts
+++ b/src/api/SampleProjectService/index.ts
@@ -1,0 +1,25 @@
+import { GetSampleProjectResponseDto } from "@/types/dto/SampleProjectService";
+
+/**
+ * SampleProjectService의 유즈케이스에서 사용할 fetch 함수를 정의합니다.
+ * 유즈케이스를 실제로 구현한 hook이 너무 커지는 것을 방지하기 위해 분리해두었습니다.
+ */
+
+/**
+ *
+ */
+export const getSampleProject = (
+  id: number,
+): Promise<GetSampleProjectResponseDto> =>
+  // 올바른 fetch 방식인지 테스트 필요합니다. 원래 상대경로로 적었으나 next.js 18 버전 이상은 절대경로만 인식한다는 얘기가 있어서 일단 이렇게 적었습니다.
+  fetch(`/api/mock/project/${id}`).then((res) =>
+    res.ok ? res.json() : Promise.reject(res),
+  );
+
+export const postSampleProject = (
+  body: any, // post body에 들어갈 타입은 user와 달리 정의되어 있지 않은데, 어떻게 구현하면 좋을까요?
+): Promise<GetSampleProjectResponseDto> =>
+  fetch(`/api/mock/project/${id}/finish`, {
+    method: "POST",
+    body: JSON.stringify(body),
+  }).then(async (res) => (res.ok ? res.json() : Promise.reject(res)));

--- a/src/app/watch/[id]/page.tsx
+++ b/src/app/watch/[id]/page.tsx
@@ -5,7 +5,7 @@ import { useSampleProjectService } from "@/hooks/SampleProjectService";
 
 type WatchProps = {
   params: {
-    id: number;
+    id: string;
   };
 };
 

--- a/src/app/watch/[id]/page.tsx
+++ b/src/app/watch/[id]/page.tsx
@@ -11,10 +11,12 @@ type WatchProps = {
 
 export default function Watch(props: WatchProps) {
   const id = props.params.id;
-  const { status, project } = useSampleProjectService(id);
+  const { status, project, finishWatchingProject } =
+    useSampleProjectService(id);
 
   return (
     <>
+      <button onClick={() => finishWatchingProject()}>test button</button>
       {status === "fetching" && <div>로딩 중</div>}
       {status === "fail" && <div>실패</div>}
       {status === "success" && <Player src={project.src} />}

--- a/src/app/watch/[id]/page.tsx
+++ b/src/app/watch/[id]/page.tsx
@@ -1,44 +1,23 @@
 "use client";
 
 import Player from "@/components/Watch/Player/Player";
-import { useState, useEffect } from "react";
+import { useSampleProjectService } from "@/hooks/SampleProjectService";
 
 type WatchProps = {
   params: {
-    id: string;
+    id: number;
   };
 };
 
 export default function Watch(props: WatchProps) {
   const id = props.params.id;
-  const [videoSource, setVideoSource] = useState("");
-  const [errorMessage, setErrorMessage] = useState("");
-  useEffect(() => {
-    if (id) {
-      const callVideo = async () => {
-        try {
-          const response = await fetch(`/api/mock/project/${id}`);
-
-          if (response.ok) {
-            const data = await response.json();
-            setVideoSource(data.src);
-          } else {
-            // 에러 발생 시 조건부로 errorMessage를 useState에 저장
-            const data = await response.json();
-            data.error_fields
-              ? setErrorMessage(data.error_fields[0].error_message)
-              : setErrorMessage(data.error_message);
-          }
-        } catch (error) {
-          console.error(error);
-        }
-      };
-
-      callVideo();
-    }
-  }, [id]);
+  const { status, project } = useSampleProjectService(id);
 
   return (
-    <>{errorMessage ? <p>{errorMessage}</p> : <Player src={videoSource} />}</>
+    <>
+      {status === "fetching" && <div>로딩 중</div>}
+      {status === "fail" && <div>실패</div>}
+      {status === "success" && <Player src={project.src} />}
+    </>
   );
 }

--- a/src/app/watch/[id]/page.tsx
+++ b/src/app/watch/[id]/page.tsx
@@ -19,7 +19,12 @@ export default function Watch(props: WatchProps) {
       <button onClick={() => finishWatchingProject()}>test button</button>
       {status === "fetching" && <div>로딩 중</div>}
       {status === "fail" && <div>실패</div>}
-      {status === "success" && <Player src={project.src} />}
+      {status === "success" && (
+        <Player
+          src={project.src}
+          finishWatchingProject={finishWatchingProject}
+        />
+      )}
     </>
   );
 }

--- a/src/components/Watch/Player/Player.tsx
+++ b/src/components/Watch/Player/Player.tsx
@@ -12,9 +12,10 @@ import { DocumentWithFullScreen } from "@/types/utility/polyfills";
 
 interface PlayerProps {
   src: string;
+  finishWatchingProject: () => void;
 }
 
-function Player({ src }: PlayerProps) {
+function Player({ src, finishWatchingProject }: PlayerProps) {
   const videoRef = useRef<HTMLVideoElement | null>(null);
   const [isPlaying, setIsPlaying] = useState(false);
   const [currentTime, setCurrentTime] = useState(0);
@@ -38,7 +39,7 @@ function Player({ src }: PlayerProps) {
         setCurrentTime(currentVideo.currentTime);
       });
 
-      currentVideo.addEventListener("ended", () => {});
+      currentVideo.addEventListener("ended", finishWatchingProject);
 
       // Detect full-screen change
       const handleFullScreenChange = () => {
@@ -66,6 +67,7 @@ function Player({ src }: PlayerProps) {
           // Clean up event listeners when the component unmounts
           currentVideo.removeEventListener("canplay", () => {});
           currentVideo.removeEventListener("timeupdate", () => {});
+          currentVideo.removeEventListener("ended", () => {});
         }
 
         // Clean up full-screen change listeners

--- a/src/components/Watch/Player/Player.tsx
+++ b/src/components/Watch/Player/Player.tsx
@@ -32,11 +32,13 @@ function Player({ src }: PlayerProps) {
         setDuration(currentVideo.duration);
       });
 
-      // // Update currentTime while the video is playing
+      // Update currentTime while the video is playing
       currentVideo.addEventListener("timeupdate", () => {
         if (!currentVideo?.duration || !src) return;
         setCurrentTime(currentVideo.currentTime);
       });
+
+      currentVideo.addEventListener("ended", () => {});
 
       // Detect full-screen change
       const handleFullScreenChange = () => {

--- a/src/hooks/SampleProjectService/index.ts
+++ b/src/hooks/SampleProjectService/index.ts
@@ -4,7 +4,7 @@ import { SampleProjectService } from "@/types/usecase/SampleProjectService";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import {
   getSampleProjectById,
-  postSampleProject,
+  postSampleProjectById,
 } from "@/api/SampleProjectService";
 
 type InjectedUsecase = SampleProjectService<GetSampleProjectResponseDto>; // 의미에 맞는 적절한 DTO를 Generic으로 주입해줍니다.
@@ -28,7 +28,7 @@ export const useSampleProjectService = (id: string): InjectedUsecase => {
 
   // useMutation을 이용한 POST 시도
   const { mutate } = useMutation({
-    mutationFn: postSampleProject,
+    mutationFn: postSampleProjectById(id),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["project", id] }); // POST 성공 시 ["project", id] 쿼리를 새로고침해줍니다
     },

--- a/src/hooks/SampleProjectService/index.ts
+++ b/src/hooks/SampleProjectService/index.ts
@@ -1,0 +1,58 @@
+import { useMemo } from "react";
+import { GetSampleProjectResponseDto } from "@/types/dto/SampleProjectService";
+import { SampleProjectService } from "@/types/usecase/SampleProjectService";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+
+type InjectedUsecase = SampleProjectService<GetSampleProjectResponseDto>; // 의미에 맞는 적절한 DTO를 Generic으로 주입해줍니다.
+
+/**
+ * SampleUserService 유즈케이스를 위한 구현체입니다.
+ * 각 코드에 대한 설명을 자세히 달아놓았으니 참고하시기 바랍니다.
+ */
+export const useSampleProjectService = (id: number): InjectedUsecase => {
+  // query를 관리하는 객체
+  const queryClient = useQueryClient();
+
+  // useQuery를 이용한 비디오 가져오기
+  const { data, error, status } = useQuery({
+    queryKey: ["project", id],
+    queryFn: () =>
+      fetch(`/api/mock/project/${id}`).then((res) =>
+        res.ok ? res.json() : Promise.reject(res),
+      ), // api에서 정의한 함수를 가져오면 fail이 떠서, useQuery 내에서 정의했습니다(에러 원인 파악 필요).
+    staleTime: 1000 * 60,
+    gcTime: 1000 * 60 * 60,
+    retry: 0,
+  });
+
+  // useMutation을 이용한 POST 시도
+  const { mutate } = useMutation({
+    mutationFn: (body: any): Promise<GetSampleProjectResponseDto> =>
+      fetch(`/api/mock/project/${id}/finish`, {
+        method: "POST",
+        body: JSON.stringify(body),
+      }).then(async (res) => (res.ok ? res.json() : Promise.reject(res))),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["project", id] }); // POST 성공 시 ["project", id] 쿼리를 새로고침해줍니다
+    },
+  });
+
+  // useQuery의 결과값으로부터 status & me & error 값을 파싱합니다.
+  // useMemo를 써 parsedFetchResult의 값에 영향을 주지 않는 리렌더링 시에는 캐싱된 값을 사용합니다.
+  const parsedFetchResult = useMemo(() => {
+    switch (status) {
+      case "pending":
+        return {
+          status: "fetching", // usecase에서 요구한 대로 status를 바꿔주어야 합니다. 바꾼 결과는 타입
+          project: data ?? null,
+          error: error ?? null,
+        } as const; // 이렇게 하면 타입스크립트에게 status가 string union 타입임을 알려줄 수 있습니다.
+      case "error":
+        return { status: "fail", project: null, error } as const;
+      case "success":
+        return { status: "success", project: data, error: null } as const;
+    }
+  }, [status, data, error]);
+
+  return { ...parsedFetchResult, finishWathcingProject: mutate }; // 유즈케이스의 타입과 동일한 객체를 반환합니다.
+};

--- a/src/hooks/SampleProjectService/index.ts
+++ b/src/hooks/SampleProjectService/index.ts
@@ -2,7 +2,10 @@ import { useMemo } from "react";
 import { GetSampleProjectResponseDto } from "@/types/dto/SampleProjectService";
 import { SampleProjectService } from "@/types/usecase/SampleProjectService";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { getSampleProjectById } from "@/api/SampleProjectService";
+import {
+  getSampleProjectById,
+  postSampleProject,
+} from "@/api/SampleProjectService";
 
 type InjectedUsecase = SampleProjectService<GetSampleProjectResponseDto>; // 의미에 맞는 적절한 DTO를 Generic으로 주입해줍니다.
 
@@ -25,11 +28,7 @@ export const useSampleProjectService = (id: string): InjectedUsecase => {
 
   // useMutation을 이용한 POST 시도
   const { mutate } = useMutation({
-    mutationFn: (body: any): Promise<GetSampleProjectResponseDto> =>
-      fetch(`/api/mock/project/${id}/finish`, {
-        method: "POST",
-        body: JSON.stringify(body),
-      }).then(async (res) => (res.ok ? res.json() : Promise.reject(res))),
+    mutationFn: postSampleProject,
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["project", id] }); // POST 성공 시 ["project", id] 쿼리를 새로고침해줍니다
     },

--- a/src/hooks/SampleProjectService/index.ts
+++ b/src/hooks/SampleProjectService/index.ts
@@ -51,5 +51,5 @@ export const useSampleProjectService = (id: string): InjectedUsecase => {
     }
   }, [status, data, error]);
 
-  return { ...parsedFetchResult, finishWathcingProject: mutate }; // 유즈케이스의 타입과 동일한 객체를 반환합니다.
+  return { ...parsedFetchResult, finishWatchingProject: mutate }; // 유즈케이스의 타입과 동일한 객체를 반환합니다.
 };

--- a/src/hooks/SampleProjectService/index.ts
+++ b/src/hooks/SampleProjectService/index.ts
@@ -2,6 +2,7 @@ import { useMemo } from "react";
 import { GetSampleProjectResponseDto } from "@/types/dto/SampleProjectService";
 import { SampleProjectService } from "@/types/usecase/SampleProjectService";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { getSampleProjectById } from "@/api/SampleProjectService";
 
 type InjectedUsecase = SampleProjectService<GetSampleProjectResponseDto>; // 의미에 맞는 적절한 DTO를 Generic으로 주입해줍니다.
 
@@ -9,17 +10,14 @@ type InjectedUsecase = SampleProjectService<GetSampleProjectResponseDto>; // 의
  * SampleUserService 유즈케이스를 위한 구현체입니다.
  * 각 코드에 대한 설명을 자세히 달아놓았으니 참고하시기 바랍니다.
  */
-export const useSampleProjectService = (id: number): InjectedUsecase => {
+export const useSampleProjectService = (id: string): InjectedUsecase => {
   // query를 관리하는 객체
   const queryClient = useQueryClient();
 
   // useQuery를 이용한 비디오 가져오기
   const { data, error, status } = useQuery({
     queryKey: ["project", id],
-    queryFn: () =>
-      fetch(`/api/mock/project/${id}`).then((res) =>
-        res.ok ? res.json() : Promise.reject(res),
-      ), // api에서 정의한 함수를 가져오면 fail이 떠서, useQuery 내에서 정의했습니다(에러 원인 파악 필요).
+    queryFn: getSampleProjectById(id),
     staleTime: 1000 * 60,
     gcTime: 1000 * 60 * 60,
     retry: 0,

--- a/src/types/usecase/SampleProjectService/index.ts
+++ b/src/types/usecase/SampleProjectService/index.ts
@@ -6,7 +6,7 @@ export type SampleProjectService<ProjectData> = {
    * 영상 재생이 끝났을 때 호출하는 함수입니다. (영상이 끝나거나, 중간에 나갔을 때)
    * `/api/mock/project/:project_id/finish` 엔드포인트로 POST 요청을 보냅니다.
    */
-  finishWathcingProject: (body: any) => void;
+  finishWathcingProject: () => void;
 } & (
   | {
       status: "fetching";

--- a/src/types/usecase/SampleProjectService/index.ts
+++ b/src/types/usecase/SampleProjectService/index.ts
@@ -6,7 +6,7 @@ export type SampleProjectService<ProjectData> = {
    * 영상 재생이 끝났을 때 호출하는 함수입니다. (영상이 끝나거나, 중간에 나갔을 때)
    * `/api/mock/project/:project_id/finish` 엔드포인트로 POST 요청을 보냅니다.
    */
-  finishWathcingProject: () => void;
+  finishWatchingProject: () => void;
 } & (
   | {
       status: "fetching";

--- a/src/types/usecase/SampleProjectService/index.ts
+++ b/src/types/usecase/SampleProjectService/index.ts
@@ -6,7 +6,7 @@ export type SampleProjectService<ProjectData> = {
    * 영상 재생이 끝났을 때 호출하는 함수입니다. (영상이 끝나거나, 중간에 나갔을 때)
    * `/api/mock/project/:project_id/finish` 엔드포인트로 POST 요청을 보냅니다.
    */
-  finishWathcingProject: () => void;
+  finishWathcingProject: (body: any) => void;
 } & (
   | {
       status: "fetching";

--- a/src/types/usecase/SampleProjectService/index.ts
+++ b/src/types/usecase/SampleProjectService/index.ts
@@ -1,7 +1,7 @@
 /**
  * ProjectData는 구현부에서 주입해 줄 추상화된 프로젝트의 타입입니다.
  */
-export type SampleProjectUsecase<ProjectData> = {
+export type SampleProjectService<ProjectData> = {
   /**
    * 영상 재생이 끝났을 때 호출하는 함수입니다. (영상이 끝나거나, 중간에 나갔을 때)
    * `/api/mock/project/:project_id/finish` 엔드포인트로 POST 요청을 보냅니다.


### PR DESCRIPTION
# 작업 내용
- Architecture workflow 맞게 `useSampleProjectService` hook 및 `app/watch/[id]/pages.tsx` 작업했습니다. 

# 이슈 및 궁금증
1. 우선 `SampleUserService`처럼 queryFn을 따로 작성하여 import하고자 했으나, 계속 에러가 나서(type error로 추정됨. No overload matches this call) 깡으로 가져다 썼습니다. 다이나믹 라우팅 처리된 api를 fetch해서 일어나는 문제일 수 있을 거 같은데 봐주시면 감사하겠습니다
2. 클라이언트가 접속한 페이지의 id 번호를 가져와, 그것으로 GET 및 POST 요청을 보내야 하는 것으로 이해했습니다. 그래서 `useSampleProjectService`에 `id` 파라미터를 주고, `pages` 작업할 때 넣어주는 방식으로 작업해보았습니다. 그런데 문제는.. 가령 영상이 끝난 다음에 POST 요청을 보내고 싶은데, 이것은 `components/Player.tsx`에서 `finishWatchingProject` 함수를 콜하고 싶단 말이죠? 그런데 일단 이 훅을 component 에서 불러도 되는지, 부르는 게 맞는지?
그런데 만약 그렇게 부르는 게 맞다면, component 에는 id 값이 없으니까, 파라미터에 값을 채워줄 수가 없잖아요? 그러면 id의 types를 `number | null` 이런 식으로 처리하는 건지? 굉장히 골치 아팠습니다. 그래서 POST는 일단 보류. 적합한 방식 알려주시면 감사하겠습니다.
3. Project는 User와 달리 requestbodyDTO가 없던데, 그럼 POST 시 body type은 `any`로 처리하면 되는 걸까요?
4. 리베이스 머지 제대로 한 거 맞나요? 원래 이렇게 PR 걸면 diff가 준영 작업분까지 다 뜨는 게 맞나??