### PR TITLE
feat: Add Video Context & components

### DIFF
--- a/client/src/app/video/page.tsx
+++ b/client/src/app/video/page.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import { useState } from "react";
+import { VideoContext } from "@/contexts/VideoContext";
+import VideoController from "@/components/VideoController";
+import { Clip } from "@/contexts/VideoContext";
+
+export default function Video() {
+  const [currClip, setCurrClip] = useState<Clip | null>(null);
+  const [currFrame, setCurrFrame] = useState<number | null>(null); //useRef로 변경 가능
+
+  // DB fetch pseudo code
+  const baseURL = "https://d2yo7lrb9dagdw.cloudfront.net/";
+  const getV2 = (id: string): string => `${baseURL}v2/v2_${id}.mp4`;
+
+  const V2_A = getV2("A");
+  const V2_A2 = getV2("A2");
+
+  const DB = [
+    {
+      id: "A",
+      url: V2_A,
+      next: ["A2"],
+    },
+    {
+      id: "A2",
+      url: V2_A2,
+      next: [],
+    },
+  ];
+
+  return (
+    <VideoContext.Provider
+      value={{ DB, currClip, setCurrClip, currFrame, setCurrFrame }}
+    >
+      <VideoController />
+    </VideoContext.Provider>
+  );
+}

--- a/client/src/components/Player/index.tsx
+++ b/client/src/components/Player/index.tsx
@@ -1,0 +1,8 @@
+export default function Player({ url }: { url: string }) {
+  return (
+    <>
+      {" "}
+      <video controls src={url}></video>
+    </>
+  );
+}

--- a/client/src/components/VideoController/index.tsx
+++ b/client/src/components/VideoController/index.tsx
@@ -1,0 +1,15 @@
+import { useVideoContext } from "@/contexts/VideoContext";
+import Player from "../Player";
+
+export default function VideoController() {
+  //   const context = useVideoContext();
+  const { DB, currClip, setCurrClip } = useVideoContext();
+  if (!currClip) {
+    // currClip이 없을 경우 초기 클립 설정
+    setCurrClip(DB[0]);
+  }
+
+  const nextClips = currClip?.next || [];
+
+  return <>{currClip && <Player url={currClip.url} />}</>;
+}

--- a/client/src/contexts/VideoContext.tsx
+++ b/client/src/contexts/VideoContext.tsx
@@ -1,0 +1,27 @@
+import { createContext, useContext } from "react";
+import { SetStateAction, Dispatch } from "react";
+
+type ClipID = string;
+export type Clip = { id: ClipID; url: string; next: ClipID[] };
+
+type ContextType = {
+  DB: Clip[];
+  currClip: Clip | null;
+  setCurrClip: Dispatch<SetStateAction<Clip | null>>;
+  currFrame: number | null;
+  setCurrFrame: Dispatch<SetStateAction<number | null>>;
+};
+
+const initialContext: ContextType = {
+  DB: [],
+  currClip: null,
+  setCurrClip: () => {}, // no-op
+  currFrame: null,
+  setCurrFrame: () => {}, // no-op
+};
+
+const VideoContext = createContext<ContextType>(initialContext);
+
+const useVideoContext = () => useContext(VideoContext);
+
+export { VideoContext, useVideoContext };


### PR DESCRIPTION
`contexts/VideoContext`: `Clip` 및 `ContextType`, `VideoContext` 정의
`app/Video`: `/video` page에서 확인 가능. Context 주입 및 DB pseudo로 생성
`components/VideoController`: 주입 받은 context 가운데 `setCurrClip` 사용하여 Player에 props로 넘겨주게끔 함. 다음 영상으로 넘어가는 로직도 여기에 처리하면 되지 않을까 생각함. 참고로 `currClip, setCurrClip`은 url string만 받는 것이 아니라 아예 `Clip` 객체를 전부 받는 것으로 수정했습니다.
`components/Player`: 받은 url에 따라 video 재생하는 pure component. 여기도 context로 받을 수 있지만 일단 props로 처리해 두었음. 뭐가 더 좋을지는 만들면서 생각해 보겠습니다.